### PR TITLE
Remove unused method.

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -42,7 +42,6 @@ class Request implements RequestInterface
      */
     public function __construct(string $uri = null, string $method = self::METHOD_GET, $body = 'php://temp', array $headers = [])
     {
-        $this->validateMethod($method);
         $this->validateUri($uri);
         $this->setHeaders($headers);
         $this->method = $method;


### PR DESCRIPTION
```
[2018-10-23 17:19:50 *47923.6]  ERROR   zm_deactivate_swoole (ERROR 503): Fatal error: Uncaught Error: Call to undefined method Igni\Network\Http\ServerRequest::validateMethod() in /Users/roquie/google_drive/projects/ioteamc/calcifer/contacts/vendor/igniphp/network/src/Http/Request.php:45
Stack trace:
#0 /Users/roquie/google_drive/projects/ioteamc/calcifer/contacts/vendor/igniphp/network/src/Http/ServerRequest.php(66): Igni\Network\Http\Request->__construct('/contact/2420ab...', 'PUT', '{\n\t"user_id": "...', Array)
#1 /Users/roquie/google_drive
```